### PR TITLE
Inherit LD_PRELOAD env vars to support sysconfcpus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
     if [[ "$CHECK_INSTALL" == 'yes' ]]; then
       pip install .
       elm-doc --help
-      python -c 'import elm_doc; assert elm_doc.elm_package_overlayer_path()'
+      python -c 'import os, elm_doc; assert elm_doc.elm_package_overlayer_env("", "", os.environ)["LD_PRELOAD"]'
     else
       tox -v
     fi

--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@ In a Python (>=3.4) [virtualenv](https://docs.python.org/3.6/library/venv.html#c
     $ pip install elm-doc
 
 Dependency on `python-magic` may require you to [install more stuff](https://github.com/ahupp/python-magic#dependencies).
+
+## Development
+
+Running tests:
+
+    $ pip install -r dev-requirements.txt
+    $ tox -e py35,...

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'click',
         'doit',
         'python-magic',
+        'retrying',
         'typing ; python_version < "3.5"',
     ],
     packages=find_packages('src', exclude=['tests']),

--- a/src/elm_doc/__init__.py
+++ b/src/elm_doc/__init__.py
@@ -1,9 +1,25 @@
+import os
+from collections import ChainMap
 import imp
 from distutils.sysconfig import get_python_lib
 
 
-def elm_package_overlayer_path():
+def _elm_package_overlayer_path():
     search_paths = __path__ + [get_python_lib()]
     (_file, overlayer_path, _desc) = imp.find_module(
         "overlay_elm_package", search_paths)
     return overlayer_path
+
+
+def elm_package_overlayer_env(use_elm_package_path, instead_of_elm_package_path):
+    overlayer_path = _elm_package_overlayer_path()
+    # todo: make overlayer support windows if we want to (can we?)
+    return dict(ChainMap(
+            {
+                'USE_ELM_PACKAGE': use_elm_package_path,
+                'INSTEAD_OF_ELM_PACKAGE': instead_of_elm_package_path,
+                'DYLD_INSERT_LIBRARIES': overlayer_path,
+                'LD_PRELOAD': overlayer_path,
+            },
+            os.environ,
+        ))

--- a/src/elm_doc/__init__.py
+++ b/src/elm_doc/__init__.py
@@ -4,6 +4,24 @@ import imp
 from distutils.sysconfig import get_python_lib
 
 
+def elm_package_overlayer_env(
+        use_elm_package_path,
+        instead_of_elm_package_path,
+        base_environ):
+    overlayer_path = _elm_package_overlayer_path()
+    # todo: make overlayer support windows if we want to (can we?)
+    return dict(ChainMap(
+            {
+                'USE_ELM_PACKAGE': use_elm_package_path,
+                'INSTEAD_OF_ELM_PACKAGE': instead_of_elm_package_path,
+                'DYLD_INSERT_LIBRARIES': _prepend_overlayer(
+                    base_environ, 'DYLD_INSERT_LIBRARIES', overlayer_path),
+                'LD_PRELOAD': _prepend_overlayer(base_environ, 'LD_PRELOAD', overlayer_path),
+            },
+            base_environ,
+        ))
+
+
 def _elm_package_overlayer_path():
     search_paths = __path__ + [get_python_lib()]
     (_file, overlayer_path, _desc) = imp.find_module(
@@ -11,15 +29,8 @@ def _elm_package_overlayer_path():
     return overlayer_path
 
 
-def elm_package_overlayer_env(use_elm_package_path, instead_of_elm_package_path):
-    overlayer_path = _elm_package_overlayer_path()
-    # todo: make overlayer support windows if we want to (can we?)
-    return dict(ChainMap(
-            {
-                'USE_ELM_PACKAGE': use_elm_package_path,
-                'INSTEAD_OF_ELM_PACKAGE': instead_of_elm_package_path,
-                'DYLD_INSERT_LIBRARIES': overlayer_path,
-                'LD_PRELOAD': overlayer_path,
-            },
-            os.environ,
-        ))
+def _prepend_overlayer(base_environ, key, overlayer_path):
+    if key in base_environ:
+        return '{}:{}'.format(overlayer_path, base_environ[key])
+    else:
+        return overlayer_path

--- a/src/elm_doc/__init__.py
+++ b/src/elm_doc/__init__.py
@@ -1,4 +1,3 @@
-import os
 from collections import ChainMap
 import imp
 from distutils.sysconfig import get_python_lib

--- a/src/elm_doc/asset_tasks.py
+++ b/src/elm_doc/asset_tasks.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import subprocess
 import shutil
 
+from retrying import retry
+
 from elm_doc import elm_platform
 from elm_doc import elm_package
 from elm_doc import node_modules
@@ -32,10 +34,7 @@ def build_assets(output_path: Path, mount_point: str = ''):
         # install elm
         elm_platform.install(root_path, package.elm_version)
         node_modules.add('jscodeshift', cwd=str(root_path))
-        subprocess.check_call(
-            ['./node_modules/.bin/elm-package', 'install', '--yes'],
-            cwd=str(root_path),
-        )
+        _install_elm_packages(str(root_path))
 
         # make artifacts
         artifacts_path = root_path / 'artifacts'
@@ -82,3 +81,15 @@ def build_assets(output_path: Path, mount_point: str = ''):
         # copy assets
         shutil.rmtree(str(output_path / 'assets'), ignore_errors=True)
         shutil.copytree(str(root_path / 'assets'), str(output_path / 'assets'))
+
+
+@retry(
+    retry_on_exception=lambda e: isinstance(e, subprocess.CalledProcessError),
+    wait_exponential_multiplier=1000,  # Wait 2^x * 1000 milliseconds between each retry,
+    wait_exponential_max=30 * 1000,  # up to 30 seconds, then 30 seconds afterwards
+    stop_max_attempt_number=10)
+def _install_elm_packages(root_path):
+    subprocess.check_call(
+        ['./node_modules/.bin/elm-package', 'install', '--yes'],
+        cwd=root_path,
+    )

--- a/src/elm_doc/package_tasks.py
+++ b/src/elm_doc/package_tasks.py
@@ -76,7 +76,8 @@ def build_package_docs_json(
 
         env = elm_package_overlayer_env(
             str(overlayed_elm_package_path),
-            str(elm_package.description_path(package)))
+            str(elm_package.description_path(package)),
+            os.environ)
         subprocess.check_call(
             [str(elm_make), '--yes', '--docs', str(output_path), '--output', '/dev/null'],
             cwd=str(package.path),

--- a/src/elm_doc/package_tasks.py
+++ b/src/elm_doc/package_tasks.py
@@ -12,7 +12,7 @@ import urllib.request
 from doit.tools import create_folder
 
 from elm_doc import elm_platform
-from elm_doc import elm_package_overlayer_path
+from elm_doc import elm_package_overlayer_env
 from elm_doc import elm_package
 from elm_doc.elm_package import ElmPackage, ModuleName
 from elm_doc import page_template
@@ -59,7 +59,6 @@ def build_package_docs_json(
         {'exposed-modules': package_modules},
         package.description,
     ))
-    overlayer_path = elm_package_overlayer_path()
     with TemporaryDirectory() as tmpdir:
         root_path = Path(tmpdir)
 
@@ -75,16 +74,9 @@ def build_package_docs_json(
             # todo: support windows if we want to
             output_path = '/dev/null'
 
-        # todo: make overlayer support windows if we want to (can we?)
-        env = dict(ChainMap(
-            {
-                'USE_ELM_PACKAGE': str(overlayed_elm_package_path),
-                'INSTEAD_OF_ELM_PACKAGE': str(elm_package.description_path(package)),
-                'DYLD_INSERT_LIBRARIES': overlayer_path,
-                'LD_PRELOAD': overlayer_path,
-            },
-            os.environ,
-        ))
+        env = elm_package_overlayer_env(
+            str(overlayed_elm_package_path),
+            str(elm_package.description_path(package)))
         subprocess.check_call(
             [str(elm_make), '--yes', '--docs', str(output_path), '--output', '/dev/null'],
             cwd=str(package.path),

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,27 @@
+from elm_doc import elm_package_overlayer_env
+
+
+def test_ld_preload_is_preserved():
+    existing_preload = 'existing.lib'
+    base_env = {
+        'DYLD_INSERT_LIBRARIES': existing_preload,
+        'LD_PRELOAD': existing_preload,
+    }
+
+    env = elm_package_overlayer_env('', '', base_env)
+
+    assert existing_preload in env['LD_PRELOAD']
+    assert existing_preload in env['DYLD_INSERT_LIBRARIES']
+
+
+def test_overlayer_environment_is_configured():
+    original_elm_package = 'elm-package.json'
+    modified_elm_package = 'tmp/elm-package.json'
+    env = elm_package_overlayer_env(modified_elm_package, original_elm_package, {})
+
+    assert env['USE_ELM_PACKAGE'] == modified_elm_package
+    assert env['INSTEAD_OF_ELM_PACKAGE'] == original_elm_package
+    # test for existence but not the actual path because the helper function
+    # to get the overlayer path is private. there might be a better way to test this?
+    assert len(env['DYLD_INSERT_LIBRARIES']) > 0
+    assert len(env['LD_PRELOAD']) > 0


### PR DESCRIPTION
sysconfcpus also uses `LD_PRELOAD` to hijack `sysconf` and override the number of cpus that elm-make thinks it has, in order not to hog the system.

elm-doc hijacks `open`, a different function, so there's no conflict: we simply need to pass on the necessary environment variables to the `elm-make` process we launch to let sysconfcpus do its thing.

Also added retrying logic (with the help of a package) to elm-package install that happens during the build.