### PR TITLE
Add support for specifying specific files and directories to include

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,20 @@ to avoid the overhead of installing Elm:
 `--validate` can check if you have all the necessary documentation in place:
 
     $ elm-doc . \
-        --elm-make ui/node_modules/elm/Elm-Platform/*/.cabal-sandbox/bin/elm-make
+        --elm-make ui/node_modules/elm/Elm-Platform/*/.cabal-sandbox/bin/elm-make \
         --validate
 
 `elm-doc` assumes you're working on an app, not a package; it will try to generate
-documentation for all modules regardless of what you have in `exposed-modules`.
-You can `--exclude` modules from the list of all modules:
+documentation for all modules regardless of what you have in the `exposed-modules` of
+your `elm-package.json`.
+You can whitelist which files and directories to include in the list of modules,
+and then `--exclude` modules by using [fnmatch](https://docs.python.org/3/library/fnmatch.html)
+patterns:
 
     $ elm-doc . --output docs \
-        --elm-make ui/node_modules/elm/Elm-Platform/*/.cabal-sandbox/bin/elm-make
-        --exclude 'Page.*'
+        --elm-make ui/node_modules/elm/Elm-Platform/*/.cabal-sandbox/bin/elm-make \
+        --exclude '*.Private.*,Blacklist.*'
+        src/Whitelist src/Main.elm
 
 For a full list of options, see:
 

--- a/src/elm_doc/cli.py
+++ b/src/elm_doc/cli.py
@@ -1,6 +1,7 @@
 import os
 import os.path
 import shutil
+from pathlib import Path
 
 import click
 import magic
@@ -69,29 +70,34 @@ if you installed Elm through npm, then try {}'''.format(perhaps_binwrap_of))
               help='url path at which the docs will be served')
 @click.option('--exclude', '-x',
               metavar='module1,module2.*',
-              help='comma-separated fnmatch pattern of modules to exclude')
+              help='comma-separated fnmatch pattern of modules to exclude from the list of included modules')
 @click.option('--validate/--no-validate',
               default=False,
               help='validate all doc comments are in place without generating docs')
+@click.option('--doit-args',
+              help='options to pass to doit.doit_cmd.DoitMain.run')
 @click.argument('project_path')
-@click.argument('doit_args', nargs=-1, type=click.UNPROCESSED)
-def main(output, elm_make, mount_at, exclude, validate, project_path, doit_args):
+@click.argument('include_paths', nargs=-1)
+def main(output, elm_make, mount_at, exclude, validate, doit_args, project_path, include_paths):
     """Generate static documentation for your Elm project"""
 
     if not validate and output is None:
         raise click.BadParameter('please specify --output directory')
 
     def task_build():
+        resolved_include_paths = [Path(path).resolve() for path in include_paths]
         exclude_modules = exclude.split(',') if exclude else []
         return create_tasks(
             os.path.abspath(project_path),
             os.path.abspath(output) if output is not None else None,
             elm_make=os.path.abspath(elm_make) if elm_make is not None else None,
+            include_paths=resolved_include_paths,
             exclude_modules=exclude_modules,
             mount_point=mount_at,
             validate=validate)
 
-    result = DoitMain(ModuleTaskLoader(locals())).run(doit_args)
+    result = DoitMain(ModuleTaskLoader(locals())).run(
+        doit_args.split(' ') if doit_args else [])
     if result is not None and result > 0:
         raise DoitException('', result)
 

--- a/src/elm_doc/cli.py
+++ b/src/elm_doc/cli.py
@@ -53,6 +53,12 @@ def validate_elm_make(ctx, param, value):
 if you installed Elm through npm, then try {}'''.format(perhaps_binwrap_of))
 
 
+def _resolve_path(path: str) -> Path:
+    # not using Path.resolve() for now because we don't expect strict
+    # existence checking. maybe we should.
+    return Path(os.path.normpath(os.path.abspath(path)))
+
+
 @click.command(context_settings=dict(
     ignore_unknown_options=True,
 ))
@@ -85,12 +91,12 @@ def main(output, elm_make, mount_at, exclude, validate, doit_args, project_path,
         raise click.BadParameter('please specify --output directory')
 
     def task_build():
-        resolved_include_paths = [Path(path).resolve() for path in include_paths]
+        resolved_include_paths = [_resolve_path(path) for path in include_paths]
         exclude_modules = exclude.split(',') if exclude else []
         return create_tasks(
-            os.path.abspath(project_path),
-            os.path.abspath(output) if output is not None else None,
-            elm_make=os.path.abspath(elm_make) if elm_make is not None else None,
+            _resolve_path(project_path),
+            _resolve_path(output) if output is not None else None,
+            elm_make=_resolve_path(elm_make) if elm_make is not None else None,
             include_paths=resolved_include_paths,
             exclude_modules=exclude_modules,
             mount_point=mount_at,

--- a/src/elm_doc/cli.py
+++ b/src/elm_doc/cli.py
@@ -77,6 +77,10 @@ def _resolve_path(path: str) -> Path:
 @click.option('--exclude', '-x',
               metavar='module1,module2.*',
               help='comma-separated fnmatch pattern of modules to exclude from the list of included modules')
+@click.option('--force-exclusion/--no-force-exclusion',
+              default=False,
+              help=('force excluding modules specified by --exclude even if '
+                    'they are explicitly specified as include_paths'))
 @click.option('--validate/--no-validate',
               default=False,
               help='validate all doc comments are in place without generating docs')
@@ -84,7 +88,16 @@ def _resolve_path(path: str) -> Path:
               help='options to pass to doit.doit_cmd.DoitMain.run')
 @click.argument('project_path')
 @click.argument('include_paths', nargs=-1)
-def main(output, elm_make, mount_at, exclude, validate, doit_args, project_path, include_paths):
+def main(
+        output,
+        elm_make,
+        mount_at,
+        exclude,
+        force_exclusion,
+        validate,
+        doit_args,
+        project_path,
+        include_paths):
     """Generate static documentation for your Elm project"""
 
     if not validate and output is None:
@@ -99,6 +112,7 @@ def main(output, elm_make, mount_at, exclude, validate, doit_args, project_path,
             elm_make=_resolve_path(elm_make) if elm_make is not None else None,
             include_paths=resolved_include_paths,
             exclude_modules=exclude_modules,
+            force_exclusion=force_exclusion,
             mount_point=mount_at,
             validate=validate)
 

--- a/src/elm_doc/elm_package.py
+++ b/src/elm_doc/elm_package.py
@@ -67,7 +67,8 @@ def iter_dependencies(package: ElmPackage) -> Iterator[ElmPackage]:
 def glob_package_modules(
         package: ElmPackage,
         include_paths: List[Path] = [],
-        exclude_patterns: List[str] = []) -> Iterator[ModuleName]:
+        exclude_patterns: List[str] = [],
+        force_exclusion: bool = False) -> Iterator[ModuleName]:
     for source_dir_name in package.source_directories:
         source_dir = package.path / source_dir_name
         elm_files = source_dir.glob('**/*.elm')
@@ -82,8 +83,11 @@ def glob_package_modules(
             rel_path = elm_file.relative_to(source_dir)
             module_name = '.'.join(rel_path.parent.parts + (rel_path.stem,))
 
-            if any(fnmatch.fnmatch(module_name, module_pattern)
-                   for module_pattern in exclude_patterns):
+            # check for excludes if there's no explicit includes, or if
+            # there are explicit includes and exclusion is requested specifically.
+            check_excludes = (not include_paths) or force_exclusion
+            if check_excludes and any(fnmatch.fnmatch(module_name, module_pattern)
+                                      for module_pattern in exclude_patterns):
                 continue
 
             yield module_name

--- a/src/elm_doc/elm_package.py
+++ b/src/elm_doc/elm_package.py
@@ -64,7 +64,10 @@ def iter_dependencies(package: ElmPackage) -> Iterator[ElmPackage]:
         yield from_path(package.path / STUFF_DIRECTORY / PACKAGES_DIRECTORY / name / version, is_dep=True)
 
 
-def glob_package_modules(package: ElmPackage, exclude_patterns: List[str] = []) -> Iterator[ModuleName]:
+def glob_package_modules(
+        package: ElmPackage,
+        include_paths: List[Path] = [],
+        exclude_patterns: List[str] = []) -> Iterator[ModuleName]:
     for source_dir_name in package.source_directories:
         source_dir = package.path / source_dir_name
         elm_files = source_dir.glob('**/*.elm')
@@ -72,8 +75,24 @@ def glob_package_modules(package: ElmPackage, exclude_patterns: List[str] = []) 
             if elm_file.relative_to(package.path).parts[0] == STUFF_DIRECTORY:
                 continue
             rel_path = elm_file.relative_to(source_dir)
-            module_name = '.'.join(rel_path.parent.parts + (rel_path.stem,))
-            if any(fnmatch.fnmatch(module_name, pattern)
-                   for pattern in exclude_patterns):
+
+            if include_paths and not any(_matches_include_path(rel_path, include_path)
+                                            for include_path in include_paths):
                 continue
+
+            module_name = '.'.join(rel_path.parent.parts + (rel_path.stem,))
+
+            if any(fnmatch.fnmatch(module_name, module_pattern)
+                   for module_pattern in exclude_patterns):
+                continue
+
             yield module_name
+
+
+def _matches_include_path(source_path: Path, include_path: Path):
+    try:
+        source_path.relative_to(include_path)
+    except ValueError:
+        return False
+    else:
+        return True

--- a/src/elm_doc/elm_package.py
+++ b/src/elm_doc/elm_package.py
@@ -77,7 +77,7 @@ def glob_package_modules(
             rel_path = elm_file.relative_to(source_dir)
 
             if include_paths and not any(_matches_include_path(rel_path, include_path)
-                                            for include_path in include_paths):
+                                         for include_path in include_paths):
                 continue
 
             module_name = '.'.join(rel_path.parent.parts + (rel_path.stem,))

--- a/src/elm_doc/elm_package.py
+++ b/src/elm_doc/elm_package.py
@@ -74,12 +74,12 @@ def glob_package_modules(
         for elm_file in elm_files:
             if elm_file.relative_to(package.path).parts[0] == STUFF_DIRECTORY:
                 continue
-            rel_path = elm_file.relative_to(source_dir)
 
-            if include_paths and not any(_matches_include_path(rel_path, include_path)
+            if include_paths and not any(_matches_include_path(elm_file, include_path)
                                          for include_path in include_paths):
                 continue
 
+            rel_path = elm_file.relative_to(source_dir)
             module_name = '.'.join(rel_path.parent.parts + (rel_path.stem,))
 
             if any(fnmatch.fnmatch(module_name, module_pattern)

--- a/src/elm_doc/package_tasks.py
+++ b/src/elm_doc/package_tasks.py
@@ -99,6 +99,7 @@ def create_package_tasks(
         output_path: Optional[Path],
         package: ElmPackage,
         elm_make: Path = None,
+        include_paths: List[str] = [],
         exclude_modules: List[str] = [],
         mount_point: str = '',
         validate: bool = False):
@@ -107,7 +108,8 @@ def create_package_tasks(
     if package.is_dep:
         package_modules = package.exposed_modules
     else:
-        package_modules = list(elm_package.glob_package_modules(package, exclude_modules))
+        package_modules = list(elm_package.glob_package_modules(
+            package, include_paths, exclude_modules))
 
     if validate:
         yield {

--- a/src/elm_doc/package_tasks.py
+++ b/src/elm_doc/package_tasks.py
@@ -108,6 +108,7 @@ def create_package_tasks(
         elm_make: Path = None,
         include_paths: List[str] = [],
         exclude_modules: List[str] = [],
+        force_exclusion: bool = False,
         mount_point: str = '',
         validate: bool = False):
     basename = package_task_basename_factory(package)
@@ -116,7 +117,7 @@ def create_package_tasks(
         package_modules = package.exposed_modules
     else:
         package_modules = list(elm_package.glob_package_modules(
-            package, include_paths, exclude_modules))
+            package, include_paths, exclude_modules, force_exclusion))
 
     if validate:
         yield {

--- a/src/elm_doc/tasks.py
+++ b/src/elm_doc/tasks.py
@@ -11,17 +11,15 @@ from elm_doc import catalog_tasks
 
 
 def create_tasks(
-        project_path: str,
-        output_dir: Optional[str] = None,
-        elm_make: Optional[str] = None,
-        include_paths: List[str] = [],
+        project_path: Path,
+        output_path: Optional[Path] = None,
+        elm_make: Optional[Path] = None,
+        include_paths: List[Path] = [],
         exclude_modules: List[str] = [],
         mount_point: str = '',
         validate: bool = False):
-    output_path = Path(os.path.normpath(output_dir)) if output_dir is not None else None
-    elm_make = Path(os.path.normpath(elm_make)) if elm_make is not None else None
     # todo: gracefully handle missing elm-package.json
-    project_package = elm_package.from_path(Path(os.path.abspath(os.path.normpath(project_path))))
+    project_package = elm_package.from_path(project_path)
     # todo: gracefully handle missing exact-dependencies.json
     deps = list(elm_package.iter_dependencies(project_package))
     all_packages = [project_package] + deps

--- a/src/elm_doc/tasks.py
+++ b/src/elm_doc/tasks.py
@@ -1,7 +1,6 @@
 '''
 '''
 from typing import List, Optional
-import os.path
 from pathlib import Path
 
 from elm_doc import elm_package

--- a/src/elm_doc/tasks.py
+++ b/src/elm_doc/tasks.py
@@ -14,6 +14,7 @@ def create_tasks(
         project_path: str,
         output_dir: Optional[str] = None,
         elm_make: Optional[str] = None,
+        include_paths: List[str] = [],
         exclude_modules: List[str] = [],
         mount_point: str = '',
         validate: bool = False):
@@ -29,6 +30,7 @@ def create_tasks(
             output_path,
             project_package,
             elm_make=elm_make,
+            include_paths=include_paths,
             exclude_modules=exclude_modules,
             mount_point=mount_point,
             validate=validate):

--- a/src/elm_doc/tasks.py
+++ b/src/elm_doc/tasks.py
@@ -15,6 +15,7 @@ def create_tasks(
         elm_make: Optional[Path] = None,
         include_paths: List[Path] = [],
         exclude_modules: List[str] = [],
+        force_exclusion: bool = False,
         mount_point: str = '',
         validate: bool = False):
     # todo: gracefully handle missing elm-package.json
@@ -29,6 +30,7 @@ def create_tasks(
             elm_make=elm_make,
             include_paths=include_paths,
             exclude_modules=exclude_modules,
+            force_exclusion=force_exclusion,
             mount_point=mount_point,
             validate=validate):
         yield task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,9 @@ def module_fixture_path():
 
 @pytest.fixture
 def make_elm_project(elm_stuff_fixture_path, module_fixture_path):
-    def for_version(elm_version, root_dir, package_overrides={}, copy_elm_stuff=False, modules=[]):
-        elm_package = dict(default_elm_package, **package_overrides)
+    def for_version(elm_version, root_dir, src_dir='.', package_overrides={}, copy_elm_stuff=False, modules=[]):
+        elm_package = dict(default_elm_package, **{'source-directories': [src_dir]})
+        elm_package.update(package_overrides)
         elm_package['elm-version'] = '{v} <= v <= {v}'.format(v=elm_version)
         root_dir.join('elm-package.json').write(json.dumps(elm_package))
         if copy_elm_stuff:
@@ -40,9 +41,10 @@ def make_elm_project(elm_stuff_fixture_path, module_fixture_path):
                 with tarfile.open(str(elm_stuff_fixture_path(elm_version))) as tar:
                     tar.extractall()
 
+        root_dir.ensure(src_dir, dir=True)
         module_root = module_fixture_path(elm_version)
         for module in modules:
-            root_dir.join(module).write(module_root.join(module).read())
+            root_dir.join(src_dir, module).write(module_root.join(module).read())
 
     return for_version
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,7 +55,7 @@ def test_cli_doit_only_arg_in_real_project(tmpdir, runner, make_elm_project):
 
     with tmpdir.as_cwd():
         tmpdir.mkdir('docs')
-        result = runner.invoke(cli.main, ['--output', 'docs', 'frontend', 'clean', '--dry-run'])
+        result = runner.invoke(cli.main, ['--output', 'docs', 'frontend', '--doit-args', 'clean', '--dry-run'])
         assert not result.exception, result.output
         assert result.exit_code == 0
 
@@ -113,6 +113,21 @@ def test_cli_validate_real_project(tmpdir, runner, overlayer, make_elm_project):
     with tmpdir.as_cwd():
         tmpdir.join('frontend', 'README.md').write('hello')
         result = runner.invoke(cli.main, ['--validate', 'frontend'])
+        assert not result.exception, result.output
+        assert result.exit_code == 0
+
+        assert output_dir.check(exists=False)
+
+
+def test_cli_validate_subset_of_real_project(tmpdir, runner, overlayer, make_elm_project):
+    elm_version = '0.18.0'
+    project_path = tmpdir.mkdir('frontend')
+    modules = ['Main.elm', 'MissingModuleComment.elm']
+    make_elm_project(elm_version, project_path, copy_elm_stuff=True, modules=modules)
+    output_dir = tmpdir.join('docs')
+    with tmpdir.as_cwd():
+        tmpdir.join('frontend', 'README.md').write('hello')
+        result = runner.invoke(cli.main, ['--validate', 'frontend', 'Main.elm'])
         assert not result.exception, result.output
         assert result.exit_code == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,7 +119,7 @@ def test_cli_validate_real_project(tmpdir, runner, overlayer, make_elm_project):
         assert output_dir.check(exists=False)
 
 
-def test_cli_validate_subset_of_real_project(tmpdir, runner, overlayer, make_elm_project):
+def test_cli_validate_subset_of_real_project_with_forced_exclusion(tmpdir, runner, overlayer, make_elm_project):
     elm_version = '0.18.0'
     project_path = tmpdir.mkdir('frontend')
     modules = ['Main.elm', 'MissingModuleComment.elm']
@@ -127,14 +127,23 @@ def test_cli_validate_subset_of_real_project(tmpdir, runner, overlayer, make_elm
     output_dir = tmpdir.join('docs')
     with tmpdir.as_cwd():
         tmpdir.join('frontend', 'README.md').write('hello')
-        result = runner.invoke(cli.main, ['--validate', 'frontend', 'Main.elm'])
+        result = runner.invoke(cli.main, [
+            'frontend',
+            'frontend/Main.elm',
+            'frontend/MissingModuleComment.elm',
+            '--validate',
+            '--exclude',
+            'MissingModuleComment',
+            '--force-exclusion',
+        ])
         assert not result.exception, result.output
         assert result.exit_code == 0
 
+        # validation should not output anything
         assert output_dir.check(exists=False)
 
 
-def test_cli_validate_invalid_project(capfd, tmpdir, runner, overlayer, make_elm_project):
+def test_cli_validate_invalid_project_with_masked_exclude(capfd, tmpdir, runner, overlayer, make_elm_project):
     elm_version = '0.18.0'
     project_path = tmpdir.mkdir('frontend')
     modules = ['MissingModuleComment.elm', 'PublicFunctionNotInAtDocs.elm']

--- a/tests/test_elm_package.py
+++ b/tests/test_elm_package.py
@@ -14,7 +14,7 @@ def test_glob_package_modules_includes_then_excludes(tmpdir, make_elm_project):
             'MissingModuleComment.elm',
             'PublicFunctionNotInAtDocs.elm',
         ])
-    package = elm_package.from_path(Path(tmpdir))
+    package = elm_package.from_path(Path(str(tmpdir)))
     include_patterns = ['Main.elm', 'MissingModuleComment.elm']
     exclude_patterns = ['MissingModuleComment']
     modules = list(elm_package.glob_package_modules(package, include_patterns, exclude_patterns))
@@ -31,7 +31,7 @@ def test_glob_package_modules_includes_all_by_default(tmpdir, make_elm_project):
             'Main.elm',
             'MissingModuleComment.elm',
         ])
-    package = elm_package.from_path(Path(tmpdir))
+    package = elm_package.from_path(Path(str(tmpdir)))
     include_patterns = []
     exclude_patterns = []
     modules = list(elm_package.glob_package_modules(package, include_patterns, exclude_patterns))

--- a/tests/test_elm_package.py
+++ b/tests/test_elm_package.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from elm_doc import elm_package
+
+
+def test_glob_package_modules_includes_then_excludes(tmpdir, make_elm_project):
+    elm_version = '0.18.0'
+    make_elm_project(
+        elm_version,
+        tmpdir,
+        copy_elm_stuff=True,
+        modules=[
+            'Main.elm',
+            'MissingModuleComment.elm',
+            'PublicFunctionNotInAtDocs.elm',
+        ])
+    package = elm_package.from_path(Path(tmpdir))
+    include_patterns = ['Main.elm', 'MissingModuleComment.elm']
+    exclude_patterns = ['MissingModuleComment']
+    modules = list(elm_package.glob_package_modules(package, include_patterns, exclude_patterns))
+    assert modules == ['Main']
+
+
+def test_glob_package_modules_includes_all_by_default(tmpdir, make_elm_project):
+    elm_version = '0.18.0'
+    make_elm_project(
+        elm_version,
+        tmpdir,
+        copy_elm_stuff=False,
+        modules=[
+            'Main.elm',
+            'MissingModuleComment.elm',
+        ])
+    package = elm_package.from_path(Path(tmpdir))
+    include_patterns = []
+    exclude_patterns = []
+    modules = list(elm_package.glob_package_modules(package, include_patterns, exclude_patterns))
+    assert modules == ['Main', 'MissingModuleComment']

--- a/tests/test_elm_package.py
+++ b/tests/test_elm_package.py
@@ -15,7 +15,7 @@ def test_glob_package_modules_includes_then_excludes(tmpdir, make_elm_project):
             'PublicFunctionNotInAtDocs.elm',
         ])
     package = elm_package.from_path(Path(str(tmpdir)))
-    include_patterns = ['Main.elm', 'MissingModuleComment.elm']
+    include_patterns = _resolve_paths(tmpdir, 'Main.elm', 'MissingModuleComment.elm')
     exclude_patterns = ['MissingModuleComment']
     modules = list(elm_package.glob_package_modules(package, include_patterns, exclude_patterns))
     assert modules == ['Main']
@@ -36,3 +36,25 @@ def test_glob_package_modules_includes_all_by_default(tmpdir, make_elm_project):
     exclude_patterns = []
     modules = list(elm_package.glob_package_modules(package, include_patterns, exclude_patterns))
     assert modules == ['Main', 'MissingModuleComment']
+
+
+def test_glob_package_modules_can_filter_path_in_non_dot_source_dir(tmpdir, make_elm_project):
+    elm_version = '0.18.0'
+    make_elm_project(
+        elm_version,
+        tmpdir,
+        src_dir='src',
+        copy_elm_stuff=False,
+        modules=[
+            'Main.elm',
+            'MissingModuleComment.elm',
+        ])
+    package = elm_package.from_path(Path(str(tmpdir)))
+    include_patterns = _resolve_paths(tmpdir, 'src/Main.elm')
+    exclude_patterns = []
+    modules = list(elm_package.glob_package_modules(package, include_patterns, exclude_patterns))
+    assert modules == ['Main']
+
+
+def _resolve_paths(tmpdir, *paths):
+    return [str(tmpdir.join(path)) for path in paths]

--- a/tests/test_elm_package.py
+++ b/tests/test_elm_package.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from elm_doc import elm_package
 
 
-def test_glob_package_modules_includes_then_excludes(tmpdir, make_elm_project):
+def test_glob_package_modules_includes_take_precedence_over_excludes(tmpdir, make_elm_project):
     elm_version = '0.18.0'
     make_elm_project(
         elm_version,
@@ -17,7 +17,27 @@ def test_glob_package_modules_includes_then_excludes(tmpdir, make_elm_project):
     package = elm_package.from_path(Path(str(tmpdir)))
     include_patterns = _resolve_paths(tmpdir, 'Main.elm', 'MissingModuleComment.elm')
     exclude_patterns = ['MissingModuleComment']
-    modules = list(elm_package.glob_package_modules(package, include_patterns, exclude_patterns))
+    modules = list(elm_package.glob_package_modules(
+        package, include_patterns, exclude_patterns, force_exclusion=False))
+    assert modules == ['Main', 'MissingModuleComment']
+
+
+def test_glob_package_modules_excludes_take_precedence_over_includes_if_forced(tmpdir, make_elm_project):
+    elm_version = '0.18.0'
+    make_elm_project(
+        elm_version,
+        tmpdir,
+        copy_elm_stuff=True,
+        modules=[
+            'Main.elm',
+            'MissingModuleComment.elm',
+            'PublicFunctionNotInAtDocs.elm',
+        ])
+    package = elm_package.from_path(Path(str(tmpdir)))
+    include_patterns = _resolve_paths(tmpdir, 'Main.elm', 'MissingModuleComment.elm')
+    exclude_patterns = ['MissingModuleComment']
+    modules = list(elm_package.glob_package_modules(
+        package, include_patterns, exclude_patterns, force_exclusion=True))
     assert modules == ['Main']
 
 
@@ -38,7 +58,7 @@ def test_glob_package_modules_includes_all_by_default(tmpdir, make_elm_project):
     assert modules == ['Main', 'MissingModuleComment']
 
 
-def test_glob_package_modules_can_filter_path_in_non_dot_source_dir(tmpdir, make_elm_project):
+def test_glob_package_modules_can_include_path_in_non_dot_source_dir(tmpdir, make_elm_project):
     elm_version = '0.18.0'
     make_elm_project(
         elm_version,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from elm_doc import tasks
 
 
@@ -6,7 +8,7 @@ def test_create_tasks_only_elm_stuff(tmpdir, make_elm_project):
     make_elm_project(elm_version, tmpdir, copy_elm_stuff=True)
     output_dir = tmpdir.join('docs')
     with tmpdir.as_cwd():
-        result = list(tasks.create_tasks('.', str(output_dir)))
+        result = list(tasks.create_tasks(Path('.'), Path(str(output_dir))))
         expected_task_names = [
             'build_package_docs_json',
             'package_page',
@@ -28,7 +30,7 @@ def test_create_tasks_only_project_modules(tmpdir, overlayer, make_elm_project):
     output_dir = tmpdir.join('docs')
     with tmpdir.as_cwd():
         tmpdir.join('README.md').write('hello')
-        result = list(tasks.create_tasks('.', str(output_dir)))
+        result = list(tasks.create_tasks(Path('.'), Path(str(output_dir))))
 
         expected_task_names = [
             'build_package_docs_json',
@@ -48,7 +50,7 @@ def test_create_tasks_for_validation(tmpdir, make_elm_project):
     make_elm_project(elm_version, tmpdir)
     output_dir = tmpdir.join('docs')
     with tmpdir.as_cwd():
-        result = list(tasks.create_tasks('.', str(output_dir), validate=True))
+        result = list(tasks.create_tasks(Path('.'), Path(str(output_dir)), validate=True))
 
         expected_task_names = [
             'validate_package_docs_json',


### PR DESCRIPTION
fixes #7

Breaking change: positional arguments that follow the first positional argument are now considered paths to include. Previously, they were passed in to `doit.doit_cmd.DoitMain.run`. You should now use `--doit-args 'args separated by space'` for that purpose.

Explicitly specified paths take precedence over the `--exclude` argument: docs are generated or validated even if the paths match the `--exclude` module pattern.

Added: `--force-exclusion` flag to reverse the behavior described above: explicitly specified include paths get ignored if they match the `--exclude` module pattern.