### PR TITLE
Pin package.elm-lang.org version (tag) to 0.18.0

### DIFF
--- a/src/elm_doc/asset_tasks.py
+++ b/src/elm_doc/asset_tasks.py
@@ -19,7 +19,7 @@ codeshifter = os.path.normpath(os.path.join(os.path.dirname(__file__), 'native',
 
 @capture_subprocess_error
 def build_assets(output_path: Path, mount_point: str = ''):
-    tarball = 'https://api.github.com/repos/elm-lang/package.elm-lang.org/tarball'
+    tarball = 'https://api.github.com/repos/elm-lang/package.elm-lang.org/tarball/0.18.0'
     with TemporaryDirectory() as tmpdir:
         root_path = Path(tmpdir)
 


### PR DESCRIPTION
package.elm-lang.org has been upgraded to 0.19, which doesn't have the expected project structure as 0.18.