### PR TITLE
Make the latest link relative so that the docs can be moved.

### DIFF
--- a/src/elm_doc/package_tasks.py
+++ b/src/elm_doc/package_tasks.py
@@ -42,7 +42,7 @@ def build_package_page(package: ElmPackage, output_path: Path, module: Optional[
 
 def link_latest_package_dir(package_dir: Path, link_path: Path):
     os.makedirs(str(package_dir), exist_ok=True)
-    link_path.symlink_to(package_dir, target_is_directory=True)
+    link_path.symlink_to(package_dir.relative_to(link_path.parent), target_is_directory=True)
 
 
 def copy_package_readme(package_readme: Path, output_path: Path):

--- a/src/elm_doc/package_tasks.py
+++ b/src/elm_doc/package_tasks.py
@@ -42,6 +42,7 @@ def build_package_page(package: ElmPackage, output_path: Path, module: Optional[
 
 def link_latest_package_dir(package_dir: Path, link_path: Path):
     os.makedirs(str(package_dir), exist_ok=True)
+    # prefer relative path to make the built documentation directory relocatable
     link_path.symlink_to(package_dir.relative_to(link_path.parent), target_is_directory=True)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+import os.path
 from click.testing import CliRunner
 from elm_doc import cli
 
@@ -82,7 +83,9 @@ def test_cli_in_real_project(tmpdir, runner, overlayer, make_elm_project):
         assert elm_lang_html_docs_path.check()
 
         package_dir = output_dir.join('packages', 'user', 'project', '1.0.0')
-        assert package_dir.dirpath('latest').check(dir=True, link=True)
+        package_latest_link = package_dir.dirpath('latest')
+        assert package_latest_link.check(dir=True, link=True)
+        assert not os.path.isabs(package_latest_link.readlink())
         assert package_dir.join('README.md').check()
 
         package_index = package_dir.join('index.html')


### PR DESCRIPTION
I noticed that I couldn't move the docs tree without breaking the `latest` links because they are absolute, e.g.

```
$ ls -l
total 4.0K
drwxrwxr-x 2 ubuntu ubuntu 4.0K Mar  8 16:07 1.0.0
lrwxrwxrwx 1 ubuntu ubuntu    5 Mar  9 09:55 latest -> /home/ubuntu/.../packages/rtfeltman/hex/1.0.0
```

This PR changes it to be relative:

```
$ ls -l
total 4.0K
drwxrwxr-x 2 ubuntu ubuntu 4.0K Mar  8 16:07 1.0.0
lrwxrwxrwx 1 ubuntu ubuntu    5 Mar  9 09:55 latest -> 1.0.0
```