### PR TITLE
Use node_modules/.bin/ over coupling to binstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ You can further point `--elm-make` at your existing installation of `elm-make` b
 to avoid the overhead of installing Elm:
 
     $ elm-doc . --output docs \
-        --elm-make ui/node_modules/elm/Elm-Platform/*/.cabal-sandbox/bin/elm-make
+        --elm-make ui/node_modules/.bin/elm-make
 
 `--validate` can check if you have all the necessary documentation in place:
 
     $ elm-doc . \
-        --elm-make ui/node_modules/elm/Elm-Platform/*/.cabal-sandbox/bin/elm-make \
+        --elm-make ui/node_modules/.bin/elm-make \
         --validate
 
 `elm-doc` assumes you're working on an app, not a package; it will try to generate
@@ -37,20 +37,20 @@ You can `--exclude` modules by using [fnmatch](https://docs.python.org/3/library
 patterns:
 
     $ elm-doc . --output docs \
-        --elm-make ui/node_modules/elm/Elm-Platform/*/.cabal-sandbox/bin/elm-make \
+        --elm-make ui/node_modules/.bin/elm-make \
         --exclude '*.Private.*,Blacklist.*'
 
 You can also specify which files and directories to include in the list of modules:
 
     $ elm-doc . --output docs \
-        --elm-make ui/node_modules/elm/Elm-Platform/*/.cabal-sandbox/bin/elm-make \
+        --elm-make ui/node_modules/.bin/elm-make \
         src/Whitelist src/Main.elm
 
 Note that the `--exclude` flag takes no effect if you explicitly specify which
 files to include, unless you add the `--force-exclusion` flag:
 
     $ elm-doc . --output docs \
-        --elm-make ui/node_modules/elm/Elm-Platform/*/.cabal-sandbox/bin/elm-make \
+        --elm-make ui/node_modules/.bin/elm-make \
         --exclude '*.Private.*,Blacklist.*' \
         --force-exclusion \
         src/Whitelist src/Main.elm

--- a/src/elm_doc/cli.py
+++ b/src/elm_doc/cli.py
@@ -43,11 +43,7 @@ def validate_elm_make(ctx, param, value):
         os.path.join(
             os.path.dirname(realpath),
             os.pardir,
-            'elm',
-            'Elm-Platform',
-            '*',
-            '.cabal-sandbox',
-            'bin',
+            '.bin',
             'elm-make'))
     raise click.BadParameter('''should be the real elm-make binary; this looks like a text file.
 if you installed Elm through npm, then try {}'''.format(perhaps_binwrap_of))


### PR DESCRIPTION
I published a new version of the Elm Platform installer, and it no longer uses the `.cabal-sandbox` directory structure.

This change should make `elm-doc` work with any version of the Elm Platform installer, since it relies on `node_modules/.bin`, which `npm` should symlink any binaries into, regardless of where they got installed.

This should fix the build on https://github.com/NoRedInk/NoRedInk/pull/19828