### PR TITLE
Typo in ElmApplication PACKAGES_DIRECTORY

### DIFF
--- a/src/elm_doc/elm_project.py
+++ b/src/elm_doc/elm_project.py
@@ -111,7 +111,7 @@ class ElmPackage(ElmProject):
 @attr.s
 class ElmApplication(ElmProject):
     DESCRIPTION_FILENAME = 'elm.json'
-    PACKAGES_DIRECTORY = 'package'
+    PACKAGES_DIRECTORY = 'packages'
 
     source_directories = attr.ib()  # [str]
     elm_version = attr.ib()  # ExactVersion


### PR DESCRIPTION
When running elm-doc for an Elm application, it fails because it can't find dependencies since it is looking in the wrong directory.