### PR TITLE
Update poetry, drop Python 3.5 and add 3.9 to CI, etc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,13 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["35", "36", "37", "38"]
+        python: ["36", "37", "38", "39"]
         pytest_addopts: [""]
         include:
-        - python: "38"
+        - python: "39"
           tox_extra_envs: ",flake8,manifest"
           report_coverage: true
-        - python: "38"
+        - python: "39"
           pytest_addopts: "--elm-version=0.19.0"
       fail-fast: false
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,10 +32,10 @@ jobs:
         name: '${{ secrets.CACHIX_CACHE_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Build
-      uses: nick-invision/retry@v1
+      uses: nick-invision/retry@v2
       with:
-        timeout_minutes: 30
-        max_attempts: 5
+        timeout_minutes: 20
+        max_attempts: 3
         command: nix-shell --argstr pythonVersion "$PYTHON_VERSION" --run "./ci.sh"
       env:
         PYTHON_VERSION: "${{matrix.python}}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,9 @@ jobs:
     - name: Checkout LFS objects
       run: git lfs checkout
     - name: Install Nix
-      uses: cachix/install-nix-action@v10
+      uses: cachix/install-nix-action@v11
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-20.09-darwin
     - name: Configure Cachix
       uses: cachix/cachix-action@v6
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ elm-doc = "elm_doc.cli:main"
 
 [build-system]
 # should be in sync with shell.nix
-requires = ["poetry-core@https://github.com/python-poetry/poetry-core/archive/ada9bf8.tar.gz"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pythonVersion ? "38" }:
+{ pythonVersion ? "39" }:
 let
   pkgs = import <nixpkgs> {};
   python = pkgs."python${pythonVersion}".override {

--- a/shell.nix
+++ b/shell.nix
@@ -31,12 +31,12 @@ let
           };
         });
       poetry = super.poetry.overridePythonAttrs (old: rec {
-        version = "1.1.0a4-c264bc0";
+        version = "1.1.4";
         src = pkgs.fetchFromGitHub {
           owner = "python-poetry";
           repo = "poetry";
-          rev = "c264bc0"; # includes #2664
-          sha256 = "008qx6c8qgwkn5j95vz5dwnk9926i2ia4irs3gn4kcwnl4m4crz4";
+          rev = version;
+          sha256 = "0lx3qpz5dad0is7ki5a4vxphvc8cm8fnv4bmrx226a6nvvaj6ahs";
         };
         # checks depend on httpretty, which doesn't support 3.5
         doCheck = false;
@@ -44,23 +44,16 @@ let
           old.propagatedBuildInputs
           ++ (with self; [ poetry-core virtualenv ]
                          ++ pkgs.lib.optionals (pythonAtLeast "3.6") [ crashtest ] );
-        postPatch = ''
-          substituteInPlace pyproject.toml \
-           --replace "requests-toolbelt = \"^0.8.0\"" "requests-toolbelt = \"^0.9.1\"" \
-           --replace 'importlib-metadata = {version = "^1.6.0", python = "<3.8"}' \
-             'importlib-metadata = {version = ">=1.3,<2", python = "<3.8"}' \
-           --replace "tomlkit = \"^0.5.11\"" "tomlkit = \"^0.6.0\"" \
-        '';
       });
       poetry-core = self.buildPythonPackage rec {
         pname = "poetry-core";
-        version = "1.0.0a8-ada9bf8";
+        version = "1.0.0";
         format = "pyproject";
         src = pkgs.fetchFromGitHub {
           owner = "python-poetry";
           repo = pname;
-          rev = "ada9bf8";
-          sha256 = "17hzmh71wzr2ra3ql8i22lcx611nww6xk9j9vcpsv1g5z19w4pv2";
+          rev = version;
+          sha256 = "02pqkwzbg43xz2zsw8q7m0sfkj8wbw07in83gy0bk0znhljhp0vw";
         };
         nativeBuildInputs = with self; [ intreehooks ];
         dontUseSetuptoolsCheck = true;

--- a/shell.nix
+++ b/shell.nix
@@ -38,26 +38,10 @@ let
           rev = version;
           sha256 = "0lx3qpz5dad0is7ki5a4vxphvc8cm8fnv4bmrx226a6nvvaj6ahs";
         };
-        # checks depend on httpretty, which doesn't support 3.5
-        doCheck = false;
         propagatedBuildInputs =
           old.propagatedBuildInputs
-          ++ (with self; [ poetry-core virtualenv ]
-                         ++ pkgs.lib.optionals (pythonAtLeast "3.6") [ crashtest ] );
+          ++ (with self; pkgs.lib.optionals (pythonAtLeast "3.6") [ crashtest ]);
       });
-      poetry-core = self.buildPythonPackage rec {
-        pname = "poetry-core";
-        version = "1.0.0";
-        format = "pyproject";
-        src = pkgs.fetchFromGitHub {
-          owner = "python-poetry";
-          repo = pname;
-          rev = version;
-          sha256 = "02pqkwzbg43xz2zsw8q7m0sfkj8wbw07in83gy0bk0znhljhp0vw";
-        };
-        nativeBuildInputs = with self; [ intreehooks ];
-        dontUseSetuptoolsCheck = true;
-      };
       pypiserver = self.buildPythonPackage rec {
         pname = "pypiserver";
         version = "1.3.2";

--- a/shell.nix
+++ b/shell.nix
@@ -42,6 +42,16 @@ let
           old.propagatedBuildInputs
           ++ (with self; pkgs.lib.optionals (pythonAtLeast "3.6") [ crashtest ]);
       });
+      # latest master has fixes for 3.9 but there's no release yet (2020/11/2)
+      pyflakes = super.pyflakes.overridePythonAttrs (old: rec {
+        version = "2.2.0-26cf0631fe89f61d5b0ef8d6949676f051e35796";
+        src = pkgs.fetchFromGitHub {
+          owner = "PyCQA";
+          repo = "pyflakes";
+          rev = "26cf0631fe89f61d5b0ef8d6949676f051e35796";
+          sha256 = "1yc06rd01aak6lkc7h3gr7plmnyslzbm4plv7a3w7z73rsj51xqp";
+        };
+      });
       pypiserver = self.buildPythonPackage rec {
         pname = "pypiserver";
         version = "1.3.2";

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{35,36,37,38}, flake8, manifest
+envlist = py{36,37,38,39}, flake8, manifest
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Breaking

* Drop Python 3.5, which has reached its EOL

New

* Start testing in Python 3.9 and switch the default version to use in development to 3.9

Dev dependency updates

* Update Poetry to 1.1.4
* Upgrade some Actions
